### PR TITLE
Added user agent generator and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 venv
 .idea
 *.log
+.vscode
+__pycache__

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Options:
   -v, --verbose                Show verbose log
   --ignore-response            do not wait for response body
   --with-random-get-param      add random get argument to prevent cache usage
-  --user-agent TEXT            custom user agent
+  --user-agent TEXT            [OPTIONAL] custom user agent. If skipped - random UA string will be generated for each request.
   --log-to-stdout              log to console
   --restart-period INTEGER     period in seconds to restart application (reload proxies ans targets)
   --random-xff-ip              set random ip address value for X-Forwarder-For header

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ cachetools==5.0.0
 urllib3==1.26.8
 uvloop==0.16.0
 yarl==1.7.2
+fake-useragent==0.1.11


### PR DESCRIPTION
User agent generator for each request that uses fake-useragent
All changes are backward compatible, so when `--user-agent` is specified - all requests do use the same UA. When this option skipped - UA will be generated randomly for each request.